### PR TITLE
Fix tooltip text for CardboardElytraItem

### DIFF
--- a/src/main/java/net/chaolux/createcardboardthings/common/item/CardboardElytraItem.java
+++ b/src/main/java/net/chaolux/createcardboardthings/common/item/CardboardElytraItem.java
@@ -68,6 +68,6 @@ public class CardboardElytraItem extends ElytraItem {
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
-        tooltip.add(Component.translatable("tooltip.createcardboardthings.cardboard_ball").withStyle(ChatFormatting.GRAY));
+        tooltip.add(Component.translatable("tooltip.createcardboardthings.cardboard_elytra").withStyle(ChatFormatting.GRAY));
     }
 }


### PR DESCRIPTION
Fix Cardboard Elytra showing wrong tooltip (Cardboard Ball's instead of its own)